### PR TITLE
Add prompt_cache_max_len to fireworks ai chat complete

### DIFF
--- a/src/providers/fireworks-ai/chatComplete.ts
+++ b/src/providers/fireworks-ai/chatComplete.ts
@@ -37,6 +37,9 @@ export const FireworksAIChatCompleteConfig: ProviderConfig = {
     param: 'prompt_truncate_len',
     default: 1500,
   },
+  prompt_cache_max_len: {
+    param: 'prompt_cache_max_len',
+  },
   temperature: {
     param: 'temperature',
     default: 1,


### PR DESCRIPTION
**Title:**
- Add `prompt_cache_max_len` parameter to FireworksAI chat complete configuration

**Description:**
- Added `prompt_cache_max_len` to the `FireworksAIChatCompleteConfig` in `src/providers/fireworks-ai/chatComplete.ts`.
- The parameter is optional and does not have a default value or specific constraints set.

**Motivation:**
- To enable the gateway to pass the `prompt_cache_max_len` parameter to the FireworksAI API for chat completion requests, providing more control over prompt caching.

---

[Slack Thread](https://portkeytalk.slack.com/archives/D0962802R97/p1752602642228749?thread_ts=1752602642.228749&cid=D0962802R97)